### PR TITLE
All services should 'Want=' targets not just 'After='

### DIFF
--- a/container-bind.service
+++ b/container-bind.service
@@ -2,6 +2,7 @@
 Description=openSUSE bind container
 Documentation=https://build.opensuse.org/package/show/openSUSE:Factory/opensuse-bind-image
 After=network-online.target
+Wants=network-online.target
 
 [Service]
 Restart=on-failure

--- a/container-dhcp-server.service
+++ b/container-dhcp-server.service
@@ -2,6 +2,7 @@
 Description=openSUSE dhcp4 server container
 Documentation=https://build.opensuse.org/package/show/openSUSE:Factory/opensuse-dhcp-server-image
 After=network-online.target
+Wants=network-online.target
 
 [Service]
 Restart=on-failure

--- a/container-dhcp6-server.service
+++ b/container-dhcp6-server.service
@@ -2,6 +2,7 @@
 Description=openSUSE dhcp6 server container
 Documentation=https://build.opensuse.org/package/show/openSUSE:Factory/opensuse-dhcp-server-image
 After=network-online.target
+Wants=network-online.target
 
 [Service]
 Restart=on-failure

--- a/container-haproxy.service
+++ b/container-haproxy.service
@@ -2,6 +2,7 @@
 Description=openSUSE haproxy container
 Documentation=https://build.opensuse.org/package/show/openSUSE:Factory/opensuse-haproxy-image
 After=network-online.target container-bind.service
+Wants=network-online.target
 
 [Service]
 Restart=on-failure

--- a/container-image-prune.service
+++ b/container-image-prune.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Removes all unnamed images from local storage
 After=local-fs.target
+Wants=local-fs.target
 
 [Service]
 Type=oneshot

--- a/container-mariadb.service
+++ b/container-mariadb.service
@@ -2,6 +2,7 @@
 Description=openSUSE mariadb container
 Documentation=https://build.opensuse.org/package/show/openSUSE:Factory/opensuse-mariadb-image
 After=network-online.target
+Wants=network-online.target
 
 [Service]
 Restart=on-failure

--- a/container-nginx.service
+++ b/container-nginx.service
@@ -2,6 +2,7 @@
 Description=openSUSE nginx container
 Documentation=https://build.opensuse.org/package/show/openSUSE:Factory/opensuse-nginx-image
 After=network-online.target
+Wants=network-online.target
 
 [Service]
 Restart=on-failure

--- a/container-openldap.service
+++ b/container-openldap.service
@@ -2,6 +2,7 @@
 Description=openSUSE OpenLDAP container
 Documentation=https://build.opensuse.org/package/show/openSUSE:Factory/opensuse-openldap-image
 After=network-online.target
+Wants=network-online.target
 
 [Service]
 Restart=on-failure

--- a/container-postfix.service
+++ b/container-postfix.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=openSUSE postfix container
 Documentation=https://build.opensuse.org/package/show/openSUSE:Factory/opensuse-postfix-image
-After=network-online.target
-After=container-openldap.service
+After=network-online.target container-openldap.service
+Wants=network-online.target container-openldap.service
 
 [Service]
 Restart=on-failure

--- a/container-squid.service
+++ b/container-squid.service
@@ -2,6 +2,7 @@
 Description=openSUSE squid container
 Documentation=https://build.opensuse.org/package/show/openSUSE:Factory/opensuse-squid-image
 After=network-online.target
+Wants=network-online.target
 
 [Service]
 Restart=on-failure


### PR DESCRIPTION
As discovered after debugging, our containers need to have `Wants=network-online.target` to make sure they start after the network has started

This matches the documentation upsteam also

https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/

This change has been tested with drop-ins on futec.suse.de