### PR TITLE
Only restart containers when the process fails abnormally

### DIFF
--- a/container-bind.service
+++ b/container-bind.service
@@ -5,7 +5,7 @@ After=network-online.target local-fs.target firewalld.service
 Wants=network-online.target
 
 [Service]
-Restart=on-failure
+Restart=on-abnormal
 EnvironmentFile=/usr/etc/default/container-bind
 EnvironmentFile=-/etc/default/container-bind
 ExecStartPre=-/usr/bin/mkdir -p ${CONFIG_DIR}

--- a/container-dhcp-server.service
+++ b/container-dhcp-server.service
@@ -5,7 +5,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-Restart=on-failure
+Restart=on-abnormal
 EnvironmentFile=/usr/etc/default/container-dhcp-server
 EnvironmentFile=-/etc/default/container-dhcp-server
 ExecStartPre=-/usr/bin/mkdir -p ${CONFIG_DIR}

--- a/container-dhcp6-server.service
+++ b/container-dhcp6-server.service
@@ -5,7 +5,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-Restart=on-failure
+Restart=on-abnormal
 EnvironmentFile=/usr/etc/default/container-dhcp-server
 EnvironmentFile=-/etc/default/container-dhcp-server
 ExecStartPre=-/usr/bin/mkdir -p ${CONFIG_DIR}

--- a/container-haproxy.service
+++ b/container-haproxy.service
@@ -5,7 +5,7 @@ After=network-online.target container-bind.service
 Wants=network-online.target
 
 [Service]
-Restart=on-failure
+Restart=on-abnormal
 EnvironmentFile=/usr/etc/default/container-haproxy
 EnvironmentFile=-/etc/default/container-haproxy
 ExecStartPre=-/usr/bin/podman stop haproxy

--- a/container-mariadb.service
+++ b/container-mariadb.service
@@ -5,7 +5,7 @@ After=network-online.target local-fs.target firewalld.service
 Wants=network-online.target
 
 [Service]
-Restart=on-failure
+Restart=on-abnormal
 EnvironmentFile=/usr/etc/default/container-mariadb
 EnvironmentFile=-/etc/default/container-mariadb
 ExecStartPre=-/usr/bin/mkdir -p ${DATA_DIR}

--- a/container-nginx.service
+++ b/container-nginx.service
@@ -5,7 +5,7 @@ After=network-online.target local-fs.target firewalld.service
 Wants=network-online.target
 
 [Service]
-Restart=on-failure
+Restart=on-abnormal
 EnvironmentFile=/usr/etc/default/container-nginx
 EnvironmentFile=-/etc/default/container-nginx
 ExecStartPre=-/usr/bin/mkdir -p ${NGINX_CFG} ${HTDOCS_DIR}

--- a/container-openldap.service
+++ b/container-openldap.service
@@ -5,7 +5,7 @@ After=network-online.target local-fs.target firewalld.service
 Wants=network-online.target
 
 [Service]
-Restart=on-failure
+Restart=on-abnormal
 EnvironmentFile=/usr/etc/default/container-openldap
 EnvironmentFile=-/etc/default/container-openldap
 ExecStartPre=-/usr/bin/mkdir -p ${LDAP_DB_DIR} ${LDAP_ETC_DIR} ${LDAP_CERTS_DIR}

--- a/container-postfix.service
+++ b/container-postfix.service
@@ -5,7 +5,7 @@ After=network-online.target container-openldap.service local-fs.target firewalld
 Wants=network-online.target container-openldap.service
 
 [Service]
-Restart=on-failure
+Restart=on-abnormal
 EnvironmentFile=/usr/etc/default/container-postfix
 EnvironmentFile=-/etc/default/container-postfix
 ExecStartPre=-/usr/bin/mkdir -p ${POSTFIX_SPOOL_DIR} ${POSTFIX_VMAIL_DIR} ${EXTRA_PKI_DIR}

--- a/container-squid.service
+++ b/container-squid.service
@@ -5,7 +5,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-Restart=on-failure
+Restart=on-abnormal
 EnvironmentFile=/usr/etc/default/container-squid
 EnvironmentFile=-/etc/default/container-squid
 ExecStartPre=-/usr/bin/podman stop squid


### PR DESCRIPTION
restarting the service "on-failure" can easily cause services to loop around repeatedly if the container is misconfigured. This hinders debugging.

"on-abnormal" will ensure the container remains stopped whenever it fails with an error code, but will restart in other circumstances, including timeouts and core dumps.

note- this wouldn't be best practice if we used Docker Hub or any other rate limited registry, as the rate-limiting causes timeouts, which are considered an abnormal failure, triggering a restart, and a pull, which will keep the user limited.  "on-abort" should be used in that case.